### PR TITLE
スワイプでスクロールが失敗する問題を修正。

### DIFF
--- a/lib/content_view.dart
+++ b/lib/content_view.dart
@@ -19,9 +19,10 @@ class ContentView extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // 行番号
             Column(
               children: [
-                for (var i = 0; i < 100; i++)
+                for (var i = 0; i < 48; i++)
                   Container(
                     width: 40,
                     padding: EdgeInsets.only(top: 2, left: 20, bottom: 2),
@@ -41,6 +42,7 @@ class ContentView extends StatelessWidget {
               ],
             ),
             Padding(padding: EdgeInsets.symmetric(horizontal: 10)),
+            // 内容本体
             Expanded(child: this.content!),
           ],
         )

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -117,21 +117,14 @@ class _MyHomePageState extends State<MyHomePage>
                   ),
                 ),
                 Expanded(
-                  child: ListView(
+                  child: TabBarView(
+                    controller: _controller,
                     children: <Widget>[
-                      Container(
-                        height: 5000,
-                        child: TabBarView(
-                          controller: _controller,
-                          children: <Widget>[
-                            for (int i = 0; i < contents.length; i++)
-                              Container(
-                                child: ContentView(contents[i]["content"]),
-                                color: Layout.tabBarActiveBg,
-                              ),
-                          ],
+                      for (int i = 0; i < contents.length; i++)
+                        Container(
+                          child: ContentView(contents[i]["content"]),
+                          color: Layout.tabBarActiveBg,
                         ),
-                      ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
#18

`view.dart` と `content.dart` にそれぞれ `ListView()` widget があり、二重になっていることが原因と思われる。
前者の方を削除し、デバッグモードでは改善を確認。