### PR TITLE
`Contact` ページの SNS のアイコンをオリジナルのアスペクト比で表示するようにした。

### DIFF
--- a/lib/contact.dart
+++ b/lib/contact.dart
@@ -53,12 +53,7 @@ class Contact extends StatelessWidget {
           Container(
             width: 30.0,
             height: 30.0,
-            decoration: new BoxDecoration(
-              image: DecorationImage(
-                image: AssetImage(imagePath),
-                fit: BoxFit.fill,
-              ),
-            ),
+            child: Image(image: AssetImage(imagePath)),
           ),
           Padding(padding: EdgeInsets.all(10)),
           Layout.sentenceText(snsName),

--- a/lib/contact.dart
+++ b/lib/contact.dart
@@ -51,7 +51,6 @@ class Contact extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Container(
-            width: 30.0,
             height: 30.0,
             child: Image(image: AssetImage(imagePath)),
           ),


### PR DESCRIPTION
特に LinkedIn のオリジナルのアイコンが少し横長であるため、従来の正方形の枠組みに画像を当てはめる実装ではアイコンが縦に伸びてしまう。