### PR TITLE
年齢計算のバグを修正。

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -3,7 +3,9 @@ class Utils {
     DateTime now = DateTime.now();
     DateTime birthday = DateTime(1997, 5, 30);
     int oldness = now.year - birthday.year - 1;
-    if ((now.month >= birthday.month) && (now.day >= birthday.day)) {
+    if (now.month > birthday.month) {
+      oldness += 1;
+    } else if ((now.month == birthday.month) && (now.day >= birthday.day)) {
       oldness += 1;
     }
     return oldness;


### PR DESCRIPTION
- 現在の月が誕生月より大きいときは、誕生日を既に迎えたとして年齢を +1 する。
- 現在の月と誕生月が等しいときは、現在の日と誕生日を比較する。
- 現在の月が誕生月より小さいときは、+1 しない。