### PR TITLE
ファイル一覧のアップデート。

### DIFF
--- a/lib/bug_report.dart
+++ b/lib/bug_report.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:provider/provider.dart';
+
+import 'layout.dart';
+import 'controller.dart';
+import 'layout.dart';
+
+class BugReport extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final AcannieController _controller =
+        Provider.of<AcannieController>(context);
+
+    return Container(
+      width: 200,
+      color: Layout.fileListBg,
+    );
+  }
+}

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -74,7 +74,7 @@ class AcannieController with ChangeNotifier {
   int _activePageIndex = 0;
 
   bool get pageListSelected => _pageListSelected;
-  bool _pageListSelected = false;
+  bool _pageListSelected = true;
 
   List<PageContent>? get selectedPageContents => _selectedPageContents;
   List<PageContent>? _selectedPageContents;

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -73,8 +73,11 @@ class AcannieController with ChangeNotifier {
   int get activePageIndex => _activePageIndex;
   int _activePageIndex = 0;
 
-  bool get pageListSelected => _pageListSelected;
-  bool _pageListSelected = true;
+  bool get leftListActive => _leftListActive; // 左側のリストが表示モードになっているか
+  bool _leftListActive = true;
+  int get activeLeftBarIconIndex =>
+      _activeLeftBarIconIndex; // 左側のバーの中でアクティブになっているアイコンのindex
+  int _activeLeftBarIconIndex = 0;
 
   List<PageContent>? get selectedPageContents => _selectedPageContents;
   List<PageContent>? _selectedPageContents;
@@ -85,8 +88,15 @@ class AcannieController with ChangeNotifier {
     notifyListeners();
   }
 
-  void selectFileList() {
-    _pageListSelected = !_pageListSelected;
+  void tapLeftBarIcon(int index) {
+    // 選択されているアイコンをクリックした場合
+    if (_leftListActive == true && index == _activeLeftBarIconIndex) {
+      _leftListActive = false;
+      notifyListeners();
+      return;
+    }
+    _leftListActive = true;
+    _activeLeftBarIconIndex = index;
     notifyListeners();
   }
 }

--- a/lib/layout.dart
+++ b/lib/layout.dart
@@ -27,6 +27,8 @@ class Layout {
   static const Color fileListLabel = Color.fromARGB(255, 204, 204, 204);
   static const Color fileListBg = Color.fromARGB(255, 37, 37, 38);
   static const Color fileListActiveLabel = Color.fromARGB(255, 255, 255, 255);
+  static const Color fileListNonActiveLabel =
+      Color.fromARGB(255, 133, 133, 133);
 
   static Text titleText(String title) {
     return Text(

--- a/lib/left_bar.dart
+++ b/lib/left_bar.dart
@@ -33,18 +33,32 @@ class LeftBar extends StatelessWidget {
           for (var i = 0; i < icons.length; i++)
             Column(
               children: [
-                InkWell(
-                  hoverColor: Colors.white,
-                  child: Icon(
-                    icons[i],
-                    color: Color.fromARGB(255, 133, 133, 133),
-                    size: 30,
-                  ),
-                  onTap: () {
-                    _controller.selectFileList();
-                  },
+                Row(
+                  children: [
+                    Container(
+                      color: Colors.white,
+                      width: 2,
+                      height: 60,
+                    ),
+                    Expanded(
+                      child: Container(
+                        width: 30,
+                        color: Colors.yellow,
+                        child: InkWell(
+                          hoverColor: Colors.white,
+                          child: Icon(
+                            icons[i],
+                            color: Color.fromARGB(255, 133, 133, 133),
+                            size: 30,
+                          ),
+                          onTap: () {
+                            _controller.selectFileList();
+                          },
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-                Padding(padding: EdgeInsets.all(15)),
               ],
             ),
         ],

--- a/lib/left_bar.dart
+++ b/lib/left_bar.dart
@@ -49,6 +49,7 @@ class LeftBar extends StatelessWidget {
                     Expanded(
                       child: Container(
                         width: 30,
+                        height: 50,
                         child: InkWell(
                           hoverColor: Colors.white,
                           child: Icon(

--- a/lib/left_bar.dart
+++ b/lib/left_bar.dart
@@ -29,27 +29,35 @@ class LeftBar extends StatelessWidget {
       width: 50,
       child: Column(
         children: [
-          Padding(padding: EdgeInsets.all(10)),
           for (var i = 0; i < icons.length; i++)
             Column(
               children: [
                 Row(
                   children: [
                     Container(
-                      color: Colors.white,
+                      color: () {
+                        if (_controller.pageListSelected) {
+                          return Layout.fileListActiveLabel;
+                        }
+                        return Layout.leftBarBg;
+                      }(),
                       width: 2,
-                      height: 60,
+                      height: 45,
                     ),
                     Expanded(
                       child: Container(
                         width: 30,
-                        color: Colors.yellow,
                         child: InkWell(
                           hoverColor: Colors.white,
                           child: Icon(
                             icons[i],
-                            color: Color.fromARGB(255, 133, 133, 133),
-                            size: 30,
+                            color: () {
+                              if (_controller.pageListSelected) {
+                                return Layout.fileListActiveLabel;
+                              }
+                              return Layout.fileListNonActiveLabel;
+                            }(),
+                            size: 25,
                           ),
                           onTap: () {
                             _controller.selectFileList();

--- a/lib/left_bar.dart
+++ b/lib/left_bar.dart
@@ -34,16 +34,18 @@ class LeftBar extends StatelessWidget {
               children: [
                 Row(
                   children: [
+                    // indecator
                     Container(
                       color: () {
-                        if (_controller.pageListSelected) {
+                        if (_controller.activeLeftBarIconIndex == i) {
                           return Layout.fileListActiveLabel;
                         }
                         return Layout.leftBarBg;
                       }(),
                       width: 2,
-                      height: 45,
+                      height: 50,
                     ),
+                    // Icon
                     Expanded(
                       child: Container(
                         width: 30,
@@ -52,7 +54,7 @@ class LeftBar extends StatelessWidget {
                           child: Icon(
                             icons[i],
                             color: () {
-                              if (_controller.pageListSelected) {
+                              if (_controller.activeLeftBarIconIndex == i) {
                                 return Layout.fileListActiveLabel;
                               }
                               return Layout.fileListNonActiveLabel;
@@ -60,7 +62,7 @@ class LeftBar extends StatelessWidget {
                             size: 25,
                           ),
                           onTap: () {
-                            _controller.selectFileList();
+                            _controller.tapLeftBarIcon(i);
                           },
                         ),
                       ),

--- a/lib/search.dart
+++ b/lib/search.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:provider/provider.dart';
+
+import 'layout.dart';
+import 'controller.dart';
+import 'layout.dart';
+
+class Search extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final AcannieController _controller =
+        Provider.of<AcannieController>(context);
+
+    return Container(
+      width: 200,
+      color: Layout.fileListBg,
+    );
+  }
+}

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -9,6 +9,8 @@ import 'content_view.dart';
 import 'bottom_bar.dart';
 import 'left_bar.dart';
 import 'file_list.dart';
+import 'search.dart';
+import 'bug_report.dart';
 
 // import 'package:flutter/material.dart';
 
@@ -83,11 +85,11 @@ class MyHomePage extends StatelessWidget {
               ),
               LeftBarListContent(
                 iconData: Icons.search,
-                content: Text("Coming Soon!"),
+                content: Search(),
               ),
               LeftBarListContent(
                 iconData: Icons.bug_report,
-                content: Text("Coming Soon!"),
+                content: BugReport(),
               ),
             ];
 

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -70,7 +70,7 @@ class MyHomePage extends StatelessWidget {
                 // ページ一覧
                 Visibility(
                   child: FileList(tabController: tabController),
-                  visible: _controller.pageListSelected,
+                  visible: _controller.leftListActive,
                 ),
 
                 Expanded(

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -12,6 +12,17 @@ import 'file_list.dart';
 
 // import 'package:flutter/material.dart';
 
+// 左側のバーのアイコン関連の情報
+class LeftBarListContent {
+  IconData iconData;
+  Widget content;
+
+  LeftBarListContent({
+    required this.iconData,
+    required this.content,
+  });
+}
+
 class MyHomePage extends StatelessWidget {
   PreferredSize headerBar() {
     return PreferredSize(
@@ -64,14 +75,33 @@ class MyHomePage extends StatelessWidget {
               }
             });
 
+            // 左側のバーのアイコン関連の情報一覧
+            List<LeftBarListContent> leftBarListContents = [
+              LeftBarListContent(
+                iconData: Icons.file_copy_outlined,
+                content: FileList(tabController: tabController),
+              ),
+              LeftBarListContent(
+                iconData: Icons.search,
+                content: Text("Coming Soon!"),
+              ),
+              LeftBarListContent(
+                iconData: Icons.bug_report,
+                content: Text("Coming Soon!"),
+              ),
+            ];
+
             return Row(
               children: [
                 LeftBar(),
-                // ページ一覧
-                Visibility(
-                  child: FileList(tabController: tabController),
-                  visible: _controller.leftListActive,
-                ),
+
+                // 左側のバーのアイコンをタップしたときに表示される領域
+                for (int i = 0; i < leftBarListContents.length; i++)
+                  Visibility(
+                    child: leftBarListContents[i].content,
+                    visible: _controller.leftListActive &&
+                        _controller.activeLeftBarIconIndex == i,
+                  ),
 
                 Expanded(
                   child: Column(


### PR DESCRIPTION
## チケットへのリンク

* #48

## やったこと

* ファイル一覧の表示モードをデフォルトで ON にする。
* ファイル一覧の表示モードが ON のとき、ファイルアイコンの色を明るくする。

## やらないこと

* ファイル一覧に `image/` フォルダを作成する。 #49
* 🔍アイコンと🐞アイコンをタップしたときの動作。
* アイコン上に hover したときの動作。

## できるようになること（ユーザ目線）

* ページを開いた瞬間にファイル一覧を見ることができる。

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* Flutter 2.4.0-5.0.pre.85 • channel master • https://github.com/flutter/flutter.git
Framework • revision b217575c37 (3 weeks ago) • 2021-07-16 23:36:04 -0400
Engine • revision 14a9e9a50e
Tools • Dart 2.14.0 (build 2.14.0-321.0.dev)

## その他

* 無し